### PR TITLE
PRODENG-2625 wisper 3.0 compatiblity

### DIFF
--- a/wisper-sidekiq.gemspec
+++ b/wisper-sidekiq.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'wisper'
+  spec.add_dependency 'wisper', '>=3.0'
   spec.add_dependency 'sidekiq', '>=4.1'
 end


### PR DESCRIPTION
changes for `wisper` 3.0 compatiblity
- support 3 or 4 argument `perform` and `broadcast` methods (keyword arguments are now the 4th parameter)
- bumps `wisper` dependency to `>= 3.0`
- PR already submitted by original author of this back to original repo (`krisleech`)
